### PR TITLE
.DS_Store added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# OS generated files
+.DS_Store


### PR DESCRIPTION
I threw this in so that no one with a mac accidentally adds their .DS_Store to the repo.